### PR TITLE
Allow plugins to hook in and add do stuff on import

### DIFF
--- a/inc/class-resource-space-loader.php
+++ b/inc/class-resource-space-loader.php
@@ -68,7 +68,11 @@ class Resource_Space_Loader {
 		// Request original URL.
 		$attachment_id = wpcom_vip_download_image( $data[0]->preview );
 
+		// Update Metadata.
 		update_post_meta( $attachment_id, 'resource_space', 1 );
+
+		// Allow plugins to hook in here.
+		do_action( 'resourcespace_import_complete', $attachment_id, $resource );
 
 		if ( is_wp_error( $attachment_id ) ) {
 			wp_send_json_error( $attachment_id->get_error_message() );

--- a/resourcespace.php
+++ b/resourcespace.php
@@ -115,20 +115,3 @@ add_action( 'admin_init', function() {
     }
 
 } );
-
-add_filter( 'resourcespace_import_complete', function( $data, $resource ) {
-
-	$post_array = array(
-		'ID' => $attachment_id,
-		// 'post_content' => isset( $resource->Title ) ? sanitize_text_field( $resource->Title ),
-	);
-
-	if ( isset( $resource->Title ) ) {
-		$post_array['post_title'] = sanitize_text_field( $resource->Title );
-	}
-
-	if ( count( $post_array ) > 1 ) {
-		wp_update_post( $post_array );
-	}
-
-}, 10, 2 );

--- a/resourcespace.php
+++ b/resourcespace.php
@@ -115,3 +115,20 @@ add_action( 'admin_init', function() {
     }
 
 } );
+
+add_filter( 'resourcespace_import_complete', function( $data, $resource ) {
+
+	$post_array = array(
+		'ID' => $attachment_id,
+		// 'post_content' => isset( $resource->Title ) ? sanitize_text_field( $resource->Title ),
+	);
+
+	if ( isset( $resource->Title ) ) {
+		$post_array['post_title'] = sanitize_text_field( $resource->Title );
+	}
+
+	if ( count( $post_array ) > 1 ) {
+		wp_update_post( $post_array );
+	}
+
+}, 10, 2 );


### PR DESCRIPTION
Just fire an action. Then we can hook in and import whatever meta and update the attchment as needed.

For example: 

``` php
add_filter( 'resourcespace_import_complete', function( $data, $resource ) {

    $post_array = array(
        'ID' => $attachment_id,
        // 'post_content' => isset( $resource->Title ) ? sanitize_text_field( $resource->Title ),
    );

    if ( isset( $resource->Title ) ) {
        $post_array['post_title'] = sanitize_text_field( $resource->Title );
    }

    if ( count( $post_array ) > 1 ) {
        wp_update_post( $post_array );
    }

}, 10, 2 );
```
