### PR TITLE
Encode request args - breaks 2 word searches

### DIFF
--- a/inc/class-mexp-resource-space-service.php
+++ b/inc/class-mexp-resource-space-service.php
@@ -50,8 +50,7 @@ class MEXP_Resource_Space_Service extends MEXP_Service {
 		$request['page'] = ( $request['page'] < 1 ) ? 1 : $request['page'];
 
 		// Build the request URL.
-		$api_url = add_query_arg(
-			apply_filters( 'resourcespace_request_args', array(
+		$args = array_map( 'rawurlencode', apply_filters( 'resourcespace_request_args', array(
 				'search'           => sanitize_text_field( $request['params']['q'] ),
 				'key'              => PJ_RESOURCE_SPACE_KEY,
 				'previewsize'      => 'pre',
@@ -60,9 +59,9 @@ class MEXP_Resource_Space_Service extends MEXP_Service {
 				'results_per_page' => PJ_RESOURCE_SPACE_RESULTS_PER_PAGE,
 				'page'             => absint( $request['page'] ),
 				'restypes'         => 1, // Restrict to images only.
-			) ),
-			sprintf( '%s/plugins/api_search/', PJ_RESOURCE_SPACE_DOMAIN )
-		);
+		) ) );
+
+		$api_url = add_query_arg( $args, sprintf( '%s/plugins/api_search/', PJ_RESOURCE_SPACE_DOMAIN ) );
 
 		$request_args = array(
 			'headers' => array()

--- a/inc/class-resource-space-loader.php
+++ b/inc/class-resource-space-loader.php
@@ -35,17 +35,15 @@ class Resource_Space_Loader {
 			wp_send_json_error( esc_html__( 'Empty resource id', 'resourcespace' ) );
 		}
 
-		$url = PJ_RESOURCE_SPACE_DOMAIN . '/plugins/api_search/';
-		$key = PJ_RESOURCE_SPACE_KEY;
-
-		$url = add_query_arg( array(
-			'key'              => $key,
+		$args = array_map( 'rawurlencode', array(
+			'key'              => PJ_RESOURCE_SPACE_KEY,
 			'search'           => $resource_id,
 			'prettyfieldnames' => false,
 			'original'         => true,
 			'previewsize'      => 'scr',
-		), $url );
+		) );
 
+		$url          = add_query_arg( $args, PJ_RESOURCE_SPACE_DOMAIN . '/plugins/api_search/' );
 		$request_args = array( 'headers' => array() );
 
 		// Pass basic auth header if available.


### PR DESCRIPTION
I wasn't urlencoding the query args, so things broke when you searched for something with a space in it.

Simple fix. Also added the same fix anywhere I'm using `add_query_arg`
